### PR TITLE
feat: migrate ContactForm and ProductForm to FloatingLabelInput

### DIFF
--- a/src/components/contacts/ContactForm.tsx
+++ b/src/components/contacts/ContactForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { FloatingLabelInput } from "@/components/ui/floating-label-input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useNavigate } from "react-router-dom";
@@ -54,9 +54,9 @@ export const ContactForm = ({
         <form onSubmit={handleSubmit} className="space-y-8 max-w-4xl">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div className="space-y-2">
-                    <Label htmlFor="name">Name *</Label>
-                    <Input
+                    <FloatingLabelInput
                         id="name"
+                        label={<>Name <span className="text-destructive">*</span></>}
                         value={formData.name}
                         onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                         required
@@ -64,9 +64,9 @@ export const ContactForm = ({
                     />
                 </div>
                 <div className="space-y-2">
-                    <Label htmlFor="company">Company</Label>
-                    <Input
+                    <FloatingLabelInput
                         id="company"
+                        label="Company"
                         value={formData.company}
                         onChange={(e) => setFormData({ ...formData, company: e.target.value })}
                         placeholder="Acme Inc."
@@ -76,19 +76,19 @@ export const ContactForm = ({
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div className="space-y-2">
-                    <Label htmlFor="email">Email</Label>
-                    <Input
+                    <FloatingLabelInput
                         id="email"
                         type="email"
+                        label="Email"
                         value={formData.email}
                         onChange={(e) => setFormData({ ...formData, email: e.target.value })}
                         placeholder="john@example.com"
                     />
                 </div>
                 <div className="space-y-2">
-                    <Label htmlFor="phone">Phone</Label>
-                    <Input
+                    <FloatingLabelInput
                         id="phone"
+                        label="Phone"
                         value={formData.phone}
                         onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
                         placeholder="+1234567890"
@@ -97,9 +97,9 @@ export const ContactForm = ({
             </div>
 
             <div className="space-y-2">
-                <Label htmlFor="gstin">GSTIN (Tax ID)</Label>
-                <Input
+                <FloatingLabelInput
                     id="gstin"
+                    label="GSTIN (Tax ID)"
                     value={formData.gstin}
                     onChange={(e) => setFormData({ ...formData, gstin: e.target.value })}
                     placeholder="e.g. 29ABCDE1234F1Z5"
@@ -107,9 +107,9 @@ export const ContactForm = ({
             </div>
 
             <div className="space-y-2">
-                <Label htmlFor="state">State (Place of Supply)</Label>
-                <Input
+                <FloatingLabelInput
                     id="state"
+                    label="State (Place of Supply)"
                     value={formData.state}
                     onChange={(e) => setFormData({ ...formData, state: e.target.value })}
                     placeholder="e.g. Maharashtra"

--- a/src/components/products/ProductForm.tsx
+++ b/src/components/products/ProductForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { FloatingLabelInput } from "@/components/ui/floating-label-input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -385,11 +385,9 @@ export const ProductForm = ({
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div className="space-y-2">
-                    <Label htmlFor="name">
-                        {formData.type === "Service" ? "Service Name" : "Product Name"} <span className="text-destructive">*</span>
-                    </Label>
-                    <Input
+                    <FloatingLabelInput
                         id="name"
+                        label={<>{formData.type === "Service" ? "Service Name" : "Product Name"} <span className="text-destructive">*</span></>}
                         value={formData.name}
                         onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                         onBlur={() => !initialData && handleAutoSKU(formData.type)} // Only auto-gen on blur for new items
@@ -398,12 +396,10 @@ export const ProductForm = ({
                     />
                 </div>
                 <div className="space-y-2">
-                    <Label htmlFor="sku">
-                        {formData.type === "Service" ? "Service Code" : "SKU (Stock Keeping Unit)"} <span className="text-destructive">*</span>
-                    </Label>
                     <div className="flex gap-2">
-                        <Input
+                        <FloatingLabelInput
                             id="sku"
+                            label={<>{formData.type === "Service" ? "Service Code" : "SKU (Stock Keeping Unit)"} <span className="text-destructive">*</span></>}
                             value={formData.sku}
                             onChange={(e) => setFormData({ ...formData, sku: e.target.value })}
                             required
@@ -424,8 +420,8 @@ export const ProductForm = ({
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div className="space-y-2">
-                    <Label htmlFor="hsn_code">HSN/SAC Code</Label>
-                    <Input
+                    <FloatingLabelInput
+                        label="HSN/SAC Code"
                         value={formData.hsn_code}
                         onChange={(e) => setFormData({ ...formData, hsn_code: e.target.value })}
                         placeholder="HSN/SAC Code"
@@ -563,12 +559,10 @@ export const ProductForm = ({
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <div className="space-y-2">
-                    <Label htmlFor="purchase_price">
-                        {formData.type === "Service" ? "Cost Price (Optional)" : "Purchase Price"}
-                    </Label>
-                    <Input
+                    <FloatingLabelInput
                         id="purchase_price"
                         type="number"
+                        label={formData.type === "Service" ? "Cost Price (Optional)" : "Purchase Price"}
                         min="0"
                         step="0.01"
                         value={formData.purchase_price}
@@ -578,12 +572,10 @@ export const ProductForm = ({
                     />
                 </div>
                 <div className="space-y-2">
-                    <Label htmlFor="sale_price">
-                        {formData.type === "Service" ? "Service Charge" : "Sale Price"} <span className="text-destructive">*</span>
-                    </Label>
-                    <Input
+                    <FloatingLabelInput
                         id="sale_price"
                         type="number"
+                        label={<>{formData.type === "Service" ? "Service Charge" : "Sale Price"} <span className="text-destructive">*</span></>}
                         min="0"
                         step="0.01"
                         value={formData.sale_price}
@@ -594,10 +586,10 @@ export const ProductForm = ({
                 </div>
                 {formData.type === "Product" && (
                     <div className="space-y-2">
-                        <Label htmlFor="alert_quantity">Alert Quantity</Label>
-                        <Input
+                        <FloatingLabelInput
                             id="alert_quantity"
                             type="number"
+                            label="Alert Quantity"
                             min="0"
                             value={formData.alert_quantity}
                             onChange={(e) =>
@@ -664,10 +656,10 @@ export const ProductForm = ({
                             </Select>
                         </div>
                         <div className="space-y-2">
-                            <Label htmlFor="online_price">Online Price (Optional Override)</Label>
-                            <Input
+                            <FloatingLabelInput
                                 id="online_price"
                                 type="number"
+                                label="Online Price (Optional Override)"
                                 min="0"
                                 step="0.01"
                                 value={formData.online_price}

--- a/src/components/ui/floating-label-input.tsx
+++ b/src/components/ui/floating-label-input.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 
 export interface FloatingLabelInputProps
     extends React.InputHTMLAttributes<HTMLInputElement> {
-    label: string;
+    label?: React.ReactNode; // Changed from string to ReactNode to support JSX labels
     labelClassName?: string;
 }
 


### PR DESCRIPTION
- Update FloatingLabelInput to accept ReactNode labels for consistent required field styling
- Migrate ContactForm: name, company, email, phone, GSTIN, state fields
- Migrate ProductForm: name, SKU, HSN code, purchase price, sale price, alert quantity, online price
- Replace Label + Input pattern with FloatingLabelInput for cleaner forms
- Support JSX labels with styled asterisks for required fields

Affects: suppliers, customers, products, and services add/edit forms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Contact and product forms now feature floating label input fields for a cleaner, more modern interface while maintaining all existing form functionality and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->